### PR TITLE
Make calendar used configurable

### DIFF
--- a/wakeup.cfg
+++ b/wakeup.cfg
@@ -5,3 +5,4 @@ password = *** # set your password
 [alarm]
 query = wake # set any word you like to be sought
 mp3_path = /path/to/your/mp3/files/ # set your mp3 files path here
+calendar = default # set to default calendar

--- a/wakeup.py
+++ b/wakeup.py
@@ -24,6 +24,7 @@ email = parser.get('credentials', 'email')
 password = parser.get('credentials', 'password')
 q = parser.get('alarm', 'query')
 mp3_path = parser.get('alarm', 'mp3_path')
+calendar = parser.get('alarm', 'calendar')
 
 date = (datetime.now() +timedelta(days=-1)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 endDate = (datetime.now() + timedelta(days=14)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
@@ -42,7 +43,7 @@ calendar_service.ProgrammaticLogin()
 #************************************************************************************# 
 def FullTextQuery(calendar_service):
     print 'Full text query for events on Primary Calendar: \'%s\'' % (q)
-    query = GServ.CalendarEventQuery('default', 'private', 'full', q)
+    query = GServ.CalendarEventQuery(calendar, 'private', 'full', q)
     query.start_min = date       #  calling date to set the beginning of query range for the present day
     query.start_max = endDate    #  calling endDate to limit the query range to the next 14 days. change tmedelta(days) to set the range
     query.singleevents = 'true'  #  enables creation of repeating events


### PR DESCRIPTION
This will allow users to change the calendar used. It is set to use the "default" calendar by default as is the current behavior. This way users don't have to muck around in the main code to use a different calendar. For instance , I personally don't like having Thunderbird constantly remind of wake up events. I can set the "alarmclock" calendar not to remind me(in Thunderbird when adding the calendar) and still be able to write to it via Thunderbird.  I will try and make a wiki entry later to illustrate how to find the correct name to use in the config when adding new calendars to Google. Basically "somerandomestring@group.calendar.google.com", you just need to know where to look.
